### PR TITLE
jexnjeux/필수/ch12/P36

### DIFF
--- a/src/main/java/지은/ch12/P36.java
+++ b/src/main/java/지은/ch12/P36.java
@@ -1,0 +1,62 @@
+package 지은.ch12;
+/*
+Given a string containing digits from 2-9 inclusive, return all possible letter combinations that the number could represent. Return the answer in any order.
+
+A mapping of digits to letters (just like on the telephone buttons) is given below. Note that 1 does not map to any letters.
+
+Example 1:
+
+Input: digits = "23"
+Output: ["ad","ae","af","bd","be","bf","cd","ce","cf"]
+Example 2:
+
+Input: digits = ""
+Output: []
+Example 3:
+
+Input: digits = "2"
+Output: ["a","b","c"]
+
+
+Constraints:
+
+0 <= digits.length <= 4
+digits[i] is a digit in the range ['2', '9'].
+ */
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class P36 {
+    public List<String> letterCombinations(String digits) {
+        if (digits.length() == 0) {
+            return new ArrayList<String>();
+        }
+        Map<Integer, List<Character>> map = new HashMap<>();
+        map.put(2, Arrays.asList('a', 'b', 'c'));
+        map.put(3, Arrays.asList('d', 'e', 'f'));
+        map.put(4, Arrays.asList('g', 'h', 'i'));
+        map.put(5, Arrays.asList('j', 'k', 'l'));
+        map.put(6, Arrays.asList('m', 'n', 'o'));
+        map.put(7, Arrays.asList('p', 'q', 'r', 's'));
+        map.put(8, Arrays.asList('t', 'u', 'v'));
+        map.put(9, Arrays.asList('w', 'x', 'y', 'z'));
+
+        List<String> result = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        dfs(map, result, digits, sb);
+
+        return result;
+    }
+    public static void dfs(Map<Integer, List<Character>> map, List<String> result, String digits, StringBuilder sb ){
+        if (digits.isEmpty()) {
+            result.add(sb.toString());
+            return;
+        }
+        for (char c: map.get(Character.getNumericValue(digits.charAt(0)))) {
+            dfs(map, result, digits.substring(1), new StringBuilder(sb).append(c));
+        }
+    }
+}


### PR DESCRIPTION
# 전화번호 문자 조합

#74 
<img width="377" alt="스크린샷 2024-01-05 오후 2 11 02" src="https://github.com/java-algorithm-study-grp/java-algorithm-study/assets/68100358/972b649f-8a22-4530-a5c1-3fe60820c324">

- 문자열의 첫 문자가 리스트 처음에만 추가되고 이후에는 사라지는데 이유를 알지 못해 힘들었다.
  - (원인) "23"이 digits으로 들어온 경우, 첫번째 문자열인 "ab"가 완성되어 List에 저장되고 StringBuilder를 초기화시켜줬다. 이후 return되어 dfs()를 빠져나가고, 다시 2에 해당하는 문자들(`map.get(Character.getNumericValue(digits.charAt(0)))`)의 for문으로 돌아온다. 이 때 dfs의 파라미터로 sb를 넘겨주기때문에 비어있는 sb에 3에 해당하는 문자만 추가가 되는 것이었다.
  - (해결) 파라미터로 전달받은 sb를 기반으로 StringBuilder를 새로 만들고, for문으로 탐색 대상인 문자를 추가했다. 이렇게 하면 StringBuilder를 초기화할 필요도 없어진다.

  

```
// 문제의 코드
if (digits.isEmpty()) {
    result.add(sb.toString());
    sb.toLength(0);
    return;
}
for (char c: map.get(Character.getNumericValue(digits.charAt(0)))) {
    sb.append(c);
    dfs(map, result, digits.substring(1), sb);
}
```
```
// 해결된 코드
if (digits.isEmpty()) {
    result.add(sb.toString());
    return;
}
for (char c: map.get(Character.getNumericValue(digits.charAt(0)))) {
    dfs(map, result, digits.substring(1), new StringBuilder(sb).append(c));
}
```

- 기억할 메소드
  - `Character.getNumericValue()`
  - Unicode의 값을 int value로 반환 (숫자가 아니면 -1, 정수로 표현할 수 없다면 -2 반환)
