### PR TITLE
mun9659/선택/ch9/P21, mun9659/선택/ch12/P38

### DIFF
--- a/src/main/java/떨개/ch12/P38.java
+++ b/src/main/java/떨개/ch12/P38.java
@@ -1,0 +1,58 @@
+package 떨개.ch12;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+public class P38 {
+
+    public static void main(String[] args) {
+        // Ch12. 그래프
+        //  - 38. 조합(Combination)
+        //   1) 전체 수 n을 입력받아 k개의 조합을 리턴하라
+        //    - input : n = 5, k = 3
+        //    - output : [
+        //                [1,2,3],
+        //                [1,2,4],
+        //                [1,2,5],
+        //                ...
+        //                [2,4,1],
+        //                [2,4,5],
+        //                [3,4,5]
+        //               ]
+
+        int n = 5, k = 3;
+
+        combination1(n, k);
+
+    }
+
+    private static List<List<Integer>> combination1(int n, int k) {
+
+        // 1. 재귀 DFS
+        //  - 거의 유사하게 만들었으나 계속 중복되는 값이 List에 들어가게 되어 정답을 보게 됨.
+        //  - 애석하게도 재귀식에 들어가는 index 값을 index + 1로 설정하여 문제가 발생함을 확인하게 됨.
+        //  - 다시 지우고 풀어볼 예정.
+
+        List<List<Integer>> results = new ArrayList<>();
+        dfs1(results, new ArrayList<>(), n, 1, k);
+        return results;
+    }
+
+    private static void dfs1(List<List<Integer>> results, List<Integer> list, int n, int index, int k) {
+        if(k == 0) {
+            // System.out.println("list = " + list);
+            results.add(list.stream().toList());
+            return;
+        }
+
+        // System.out.println("index : " + index + " results = " + results + " list = " + list);
+
+        for(int i = index; i <= n; i++) {
+            list.add(i);
+            dfs1(results, list, n, i + 1, k - 1);
+            list.remove(Integer.valueOf(i));
+        }
+    }
+}

--- a/src/main/java/떨개/ch9/P21.java
+++ b/src/main/java/떨개/ch9/P21.java
@@ -1,0 +1,102 @@
+package 떨개.ch9;
+
+import java.util.*;
+
+public class P21 {
+
+    public static void main(String[] args) {
+        // Ch09. 스택, 큐
+        //  - 21. 중복 문자 제거
+        //   1) 중복된 문자를 제외하고 사전식 순서(Lexicographical Order)로 나열하라.
+        //      -> 사전식 순서 : 사전에서 가장 먼저 찾을 수 있는 순서
+        //    - input : dbacdcbc
+        //    - output : acdb
+
+        // String s = "dbacdcbc";
+        String s = "ebcabc";
+        System.out.println(removeDuplicate1(s));
+        // System.out.println(removeDuplicate2(s));
+    }
+
+    private static String removeDuplicate1(String s) {
+
+        // 1. Stack을 이용하는 풀이
+        //  - 스스로 생각해보는 중 -> (X, 결국 책을 봤습니다.). 먼저 풀어본 재귀 방식을 참고하여 풀어보기.
+        //  - 이해가 더 덜 되어 있어서 좀 더 신중하게 확인해야 하면서 백준에 있는 걸 비교해봐야 할 듯 합니다.
+
+        // 문자 개수를 계산해서 담아둘 변수 선언
+        Map<Character, Integer> counter = new HashMap<>();
+        // 이미 처리한 문자여부를 확인하기 위한 변수 선언
+        Map<Character, Boolean> seen = new HashMap<>();
+        // 문제 풀이에 사용할 스택 선언
+        Deque<Character> stack = new ArrayDeque<>();
+
+        // 문자별 개수 계산
+        for(char c : s.toCharArray())
+            counter.put(c, counter.get(c) == null ? 1 : counter.get(c) + 1);
+
+        for(char c : s.toCharArray()) {
+            System.out.println("counter = " + counter);
+            System.out.println("seen = " + seen);
+            System.out.println("stack = " + stack);
+
+            // 현재 처리하는 문자는 카운터에서 -1 처리
+            counter.put(c, counter.get(c) - 1);
+
+            // 이미 처리한 문자는 건너뛴다.
+            if(seen.get(c) != null && seen.get(c))
+                continue;
+
+            // 스택에 있는 문자가 현재 문자보다 더 뒤에 붙어야 할 문자라면 스택에서 제거하고 처리하지 않는 것으로 표시
+            while(!stack.isEmpty() && stack.peek() > c && counter.get(stack.peek()) > 0)
+                seen.put(stack.pop(), false);
+
+            // 현재 문자를 스택에 삽입
+            stack.push(c);
+
+            // 현재 문자를 처리한 걸로 선언
+            seen.put(c, true);
+        }
+
+        // 스택에 있는 문자를 큐 순서대로 추출하여 리턴
+        StringBuilder sb = new StringBuilder();
+        while(!stack.isEmpty())
+            sb.append(stack.pollLast());
+
+        return sb.toString();
+    }
+
+    private static String removeDuplicate2(String s) {
+
+        // 2. 재귀를 이용하는 풀이
+        //  - 도무지 방법을 떠오르는게 힘들어서 책을 봤음.
+        //  - 처음에 Set을 이용하여 개수가 같은 값의 문자열을 진행한다면 계속 확인! 한다는 생각이 거의 똑같았다.
+        //    for문으로 하나씩 확인한다는 것으로 시간 복잡도가 늘어나는 거에 걱정한 것과 재귀인 것만 제외하고.
+
+        for (Character c : toSortedSet(s)) {
+
+            String suffix = s.substring(s.indexOf(c));
+            // System.out.println(c + " " + suffix);
+
+            // suffix로 나뉜 값을 Set으로 정렬한 값과 동일하다면, 해당하는 문자를 삭제 후 계속 재귀
+            if(toSortedSet(s).equals(toSortedSet(suffix))) {
+                return c + removeDuplicate2(suffix.replace(String.valueOf(c), ""));
+            }
+        }
+
+        return "";
+    }
+
+    public static Set<Character> toSortedSet(String s) {
+
+        // 책에서는 순수 new Comparator를 이용한 정렬 방식을 사용했다.
+        Set<Character> set = new TreeSet<>(Comparator.naturalOrder());
+
+        for(int i = 0; i < s.length(); i++) {
+            set.add(s.charAt(i));
+        }
+
+        return set;
+    }
+
+}


### PR DESCRIPTION
P21. 중복 문자 제거
- 재귀와 스택을 이용한 방식으로 풀었습니다.
  1) 재귀 : 처음에 Set을 이용한 방식을 사용할 때 for문으로 예제가 10^4승까지의 예제에서 괜찮을까? 하고 괜히 걱정을 하며 책을 보고 제가 생각한 그대로가 맞았음을 확인했습니다. 다만, 여기서 for문의 기준이 Set이 아닌 'String s에 대한 for문으로 크기가 같은 식으로 진행한다!' 라는 방법이었기에 틀렸던 것이 확인되었고 매우 이해가 잘 되었습니다.
  2) Stack : 처음에 생각은 했으나 도무지 방법이 떠오르지 않았고, 재귀 방식을 보아도 Set을 그대로 이용하여 사용할 거 같아 책을 결국 보고 풀었습니다.

P38. 조합
- 재귀 DFS로 문제를 풀었습니다.
- 예전에도 자주 풀던 문제였고, 생각보다 쉽다고 생각했지만 다시 코드로 풀어쓰는게 어려워서 아직도 번거롭습니다. 계속 복기해야 할 것 같습니다.

(2024-01-05)
실수로 브랜치를 삭제하고 다시 PR을 요청했습니다.
+ P38 문제를 추가하였습니다.
