### PR TITLE
jexnjeux/필수/ch12/P41

### DIFF
--- a/src/main/java/지은/ch12/P41.java
+++ b/src/main/java/지은/ch12/P41.java
@@ -1,0 +1,65 @@
+package 지은.ch12;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/*
+You are given a list of airline tickets where tickets[i] = [fromi, toi] represent the departure and the arrival airports of one flight. Reconstruct the itinerary in order and return it.
+
+All of the tickets belong to a man who departs from "JFK", thus, the itinerary must begin with "JFK". If there are multiple valid itineraries, you should return the itinerary that has the smallest lexical order when read as a single string.
+
+For example, the itinerary ["JFK", "LGA"] has a smaller lexical order than ["JFK", "LGB"].
+You may assume all tickets form at least one valid itinerary. You must use all the tickets once and only once.
+
+Example1:
+Input: tickets = [["MUC","LHR"],["JFK","MUC"],["SFO","SJC"],["LHR","SFO"]]
+Output: ["JFK","MUC","LHR","SFO","SJC"]
+
+Example2:
+Input: tickets = [["JFK","SFO"],["JFK","ATL"],["SFO","ATL"],["ATL","JFK"],["ATL","SFO"]]
+Output: ["JFK","ATL","JFK","SFO","ATL","SFO"]
+Explanation: Another possible reconstruction is ["JFK","SFO","ATL","JFK","ATL","SFO"] but it is larger in lexical order.
+
+Constraints:
+
+1 <= tickets.length <= 300
+tickets[i].length == 2
+fromi.length == 3
+toi.length == 3
+fromi and toi consist of uppercase English letters.
+fromi != toi
+ */
+
+public class P41 {
+
+    Map<String, PriorityQueue<String>> flights;
+    List<String> route;
+
+
+    public List<String> findItinerary(List<List<String>> tickets) {
+        flights = new HashMap<>();
+        route = new ArrayList<>();
+        for (List<String> ticket : tickets) {
+            if (!flights.containsKey(ticket.get(0))) {
+                flights.put(ticket.get(0), new PriorityQueue<>());
+            }
+            flights.get(ticket.get(0)).add(ticket.get(1));
+        }
+        dfs(route, flights, "JFK");
+        return route;
+
+
+    }
+
+    public void dfs(List<String> route, Map<String, PriorityQueue<String>> flights, String from) {
+
+        while (flights.containsKey(from) && !flights.get(from).isEmpty()) {
+            dfs(route, flights, flights.get(from).poll());
+        }
+        route.add(0, from);
+    }
+
+}


### PR DESCRIPTION
# 일정 재구성
#74 

- while문에서 `flights.containsKey(from) && !flights.get(from).isEmpty()` 두 조건을 모두 고려해야 한다.
  - `flights` 맵에서 `from`키에 대한 값은 당연히 있을 것이라고 생각했다. 하지만 없을 수도 있다..🤯
  - 만약 `flights` 맵에 `from`이라는 키가 없는 경우 (`flights.containsKey(from)` 거짓), 두 번째 조건은 검사하지 않기 때문에 오류가 발생하지 않는다.
  - `flights.containsKey(from)`가 참이지만 `flights.get(from)`이 `null`인 경우에는 `!flights.get(from).isEmpty()` 부분에서 `NullPointerException`이 발생할 수 있다.

- 구현을 어떻게 할 지 생각하기
  - {from: [to1, to2, ...]} 형태로 재정렬한다. to는 사전 순서로 나열한다. 
  - 사전 순서로 나열하기 위해서 to에 우선순위 큐를 사용한다.
  - 반복되는 동작을 생각한다.
    - "JFK"에서 시작하고, "JFK"에서 출발하여 도착하는 공항들 중 사전 순서로 첫 번째 공항을 찾는다.
    - 우선순위 큐에서 가장 앞에 있는 공항을 빼낸다.
    - 빼낸 공항을 from으로 다시 dfs 함수를 실행한다.
    - dfs 함수 호출 역순으로 `route`에 공항을 추가한다.
 - 기억해야 할 메소드
   -  `List.add(index, element)`
   - index 위치에 element를 추가한다.

