### PR TITLE
jexnjeux/필수/ch14/P56

### DIFF
--- a/src/main/java/지은/ch14/P56.java
+++ b/src/main/java/지은/ch14/P56.java
@@ -1,0 +1,28 @@
+package 지은.ch14;
+/*
+Given the root of a Binary Search Tree (BST), convert it to a Greater Tree such that every key of the original BST is changed to the original key plus the sum of all keys greater than the original key in BST.
+
+As a reminder, a binary search tree is a tree that satisfies these constraints:
+
+The left subtree of a node contains only nodes with keys less than the node's key.
+The right subtree of a node contains only nodes with keys greater than the node's key.
+Both the left and right subtrees must also be binary search trees.
+
+Example 1:
+Input: root = [4,1,6,0,2,5,7,null,null,null,3,null,null,null,8]
+Output: [30,36,21,36,35,26,15,null,null,null,33,null,null,null,8]
+
+ */
+public class P56 {
+    int sum = 0;
+    public TreeNode bstToGst(TreeNode root) {
+        if (root == null) {
+            return null;
+        }
+        bstToGst(root.right);
+        sum += root.val;
+        root.val = sum;
+        bstToGst(root.left);
+        return root;
+    }
+}


### PR DESCRIPTION
# 이진 탐색 트리(BST)를 더 큰 수 합계 트리로
#94 

- 재귀적으로 트리를 오른쪽, 현재 노드, 그리고 왼쪽 순서로 순회한다.
- 이진 탐색 트리에서 오른쪽 서브 트리는 항상 현재 노드보다 큰 값으로 이루어진다.
